### PR TITLE
Fix typo in myAmp_GTK3

### DIFF
--- a/myAmp_GTK3/myAmp.c
+++ b/myAmp_GTK3/myAmp.c
@@ -82,7 +82,7 @@ static const void* extension_data (const char *uri)
 /* descriptor */
 static LV2_Descriptor const descriptor =
 {
-    "https://github.com/sjaehn/lv2tutorial/myAmp_GTK",
+    "https://github.com/sjaehn/lv2tutorial/myAmp_GTK3",
     instantiate,
     connect_port,
     activate /* or NULL */,

--- a/myAmp_GTK3/myAmp_GTK3.cpp
+++ b/myAmp_GTK3/myAmp_GTK3.cpp
@@ -48,7 +48,7 @@ int MyAmpUI::valueChangedCallback (GtkWidget* widget, gpointer data)
 
 static LV2UI_Handle instantiate(const struct LV2UI_Descriptor *descriptor, const char *plugin_uri, const char *bundle_path, LV2UI_Write_Function write_function, LV2UI_Controller controller, LV2UI_Widget *widget, const LV2_Feature *const *features)
 {
-    if (strcmp (plugin_uri, "https://github.com/sjaehn/lv2tutorial/myAmp_GTK") != 0) return nullptr;
+    if (strcmp (plugin_uri, "https://github.com/sjaehn/lv2tutorial/myAmp_GTK3") != 0) return nullptr;
     MyAmpUI* ui;
     try {ui = new MyAmpUI(write_function, controller);}
     catch (std::exception& exc)


### PR DESCRIPTION
This caused to load the plugin (tested with Carla) but the UI didn't show up, reporting an error in log because a wrong URI.